### PR TITLE
Fix UB in NtUnicodeStrMut::try_from_u16()

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::cmp::Ordering;
-use core::mem;
-
-use widestring::U16CStr;
-
-use crate::error::{NtStringError, Result};
 
 /// Generic memory layout unified for `ANSI_STRING`, `OEM_STRING`, `UNICODE_STRING`,
 /// in their mutable and immutable versions.
@@ -19,58 +14,6 @@ pub(crate) struct RawNtString<T> {
     pub(crate) maximum_length: u16,
     /// String buffer
     pub(crate) buffer: T,
-}
-
-pub(crate) fn check_from_u16(buffer: &[u16]) -> Result<u16> {
-    let elements = buffer.len();
-    let length_usize = elements
-        .checked_mul(mem::size_of::<u16>())
-        .ok_or(NtStringError::BufferSizeExceedsU16)?;
-    let length = u16::try_from(length_usize).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
-    Ok(length)
-}
-
-pub(crate) fn check_from_u16_until_nul(buffer: &[u16]) -> Result<(u16, u16)> {
-    let length;
-    let maximum_length;
-
-    match buffer.iter().position(|x| *x == 0) {
-        Some(nul_pos) => {
-            // Include the terminating NUL character in `maximum_length` ...
-            let maximum_elements = nul_pos
-                .checked_add(1)
-                .ok_or(NtStringError::BufferSizeExceedsU16)?;
-            let maximum_length_usize = maximum_elements
-                .checked_mul(mem::size_of::<u16>())
-                .ok_or(NtStringError::BufferSizeExceedsU16)?;
-            maximum_length = u16::try_from(maximum_length_usize)
-                .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
-
-            // ... but not in `length`
-            length = maximum_length - mem::size_of::<u16>() as u16;
-        }
-        None => return Err(NtStringError::NulNotFound),
-    };
-
-    Ok((length, maximum_length))
-}
-
-pub(crate) fn check_from_u16_cstr(u16cstr: &U16CStr) -> Result<(u16, u16)> {
-    let buffer = u16cstr.as_slice_with_nul();
-
-    // Include the terminating NUL character in `maximum_length` ...
-    let maximum_length_in_elements = buffer.len();
-    let maximum_length_in_bytes = maximum_length_in_elements
-        .checked_mul(mem::size_of::<u16>())
-        .ok_or(NtStringError::BufferSizeExceedsU16)?;
-    let maximum_length =
-        u16::try_from(maximum_length_in_bytes).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
-
-    // ... but not in `length`
-    debug_assert!(maximum_length >= mem::size_of::<u16>() as u16);
-    let length = maximum_length - mem::size_of::<u16>() as u16;
-
-    Ok((length, maximum_length))
 }
 
 /// Compare any two `u16` iterators and return an [`Ordering`] value.

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -2,6 +2,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::cmp::Ordering;
+use core::mem;
+
+use widestring::U16CStr;
+
+use crate::error::{NtStringError, Result};
 
 /// Generic memory layout unified for `ANSI_STRING`, `OEM_STRING`, `UNICODE_STRING`,
 /// in their mutable and immutable versions.
@@ -14,6 +19,58 @@ pub(crate) struct RawNtString<T> {
     pub(crate) maximum_length: u16,
     /// String buffer
     pub(crate) buffer: T,
+}
+
+pub(crate) fn check_from_u16(buffer: &[u16]) -> Result<u16> {
+    let elements = buffer.len();
+    let length_usize = elements
+        .checked_mul(mem::size_of::<u16>())
+        .ok_or(NtStringError::BufferSizeExceedsU16)?;
+    let length = u16::try_from(length_usize).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+    Ok(length)
+}
+
+pub(crate) fn check_from_u16_until_nul(buffer: &[u16]) -> Result<(u16, u16)> {
+    let length;
+    let maximum_length;
+
+    match buffer.iter().position(|x| *x == 0) {
+        Some(nul_pos) => {
+            // Include the terminating NUL character in `maximum_length` ...
+            let maximum_elements = nul_pos
+                .checked_add(1)
+                .ok_or(NtStringError::BufferSizeExceedsU16)?;
+            let maximum_length_usize = maximum_elements
+                .checked_mul(mem::size_of::<u16>())
+                .ok_or(NtStringError::BufferSizeExceedsU16)?;
+            maximum_length = u16::try_from(maximum_length_usize)
+                .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+
+            // ... but not in `length`
+            length = maximum_length - mem::size_of::<u16>() as u16;
+        }
+        None => return Err(NtStringError::NulNotFound),
+    };
+
+    Ok((length, maximum_length))
+}
+
+pub(crate) fn check_from_u16_cstr(u16cstr: &U16CStr) -> Result<(u16, u16)> {
+    let buffer = u16cstr.as_slice_with_nul();
+
+    // Include the terminating NUL character in `maximum_length` ...
+    let maximum_length_in_elements = buffer.len();
+    let maximum_length_in_bytes = maximum_length_in_elements
+        .checked_mul(mem::size_of::<u16>())
+        .ok_or(NtStringError::BufferSizeExceedsU16)?;
+    let maximum_length =
+        u16::try_from(maximum_length_in_bytes).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+
+    // ... but not in `length`
+    debug_assert!(maximum_length >= mem::size_of::<u16>() as u16);
+    let length = maximum_length - mem::size_of::<u16>() as u16;
+
+    Ok((length, maximum_length))
 }
 
 /// Compare any two `u16` iterators and return an [`Ordering`] value.

--- a/src/unicode_string/str.rs
+++ b/src/unicode_string/str.rs
@@ -10,7 +10,9 @@ use core::{fmt, mem, slice};
 use widestring::{U16CStr, U16Str};
 
 use crate::error::{NtStringError, Result};
-use crate::helpers::{cmp_iter, RawNtString};
+use crate::helpers::{
+    check_from_u16, check_from_u16_cstr, check_from_u16_until_nul, cmp_iter, RawNtString,
+};
 
 use super::iter::{Chars, CharsLossy};
 
@@ -158,12 +160,7 @@ impl<'a> NtUnicodeStr<'a> {
     ///
     /// [`try_from_u16_until_nul`]: Self::try_from_u16_until_nul
     pub fn try_from_u16(buffer: &'a [u16]) -> Result<Self> {
-        let elements = buffer.len();
-        let length_usize = elements
-            .checked_mul(mem::size_of::<u16>())
-            .ok_or(NtStringError::BufferSizeExceedsU16)?;
-        let length =
-            u16::try_from(length_usize).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+        let length = check_from_u16(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -191,26 +188,7 @@ impl<'a> NtUnicodeStr<'a> {
     ///
     /// [`try_from_u16`]: Self::try_from_u16
     pub fn try_from_u16_until_nul(buffer: &'a [u16]) -> Result<Self> {
-        let length;
-        let maximum_length;
-
-        match buffer.iter().position(|x| *x == 0) {
-            Some(nul_pos) => {
-                // Include the terminating NUL character in `maximum_length` ...
-                let maximum_elements = nul_pos
-                    .checked_add(1)
-                    .ok_or(NtStringError::BufferSizeExceedsU16)?;
-                let maximum_length_usize = maximum_elements
-                    .checked_mul(mem::size_of::<u16>())
-                    .ok_or(NtStringError::BufferSizeExceedsU16)?;
-                maximum_length = u16::try_from(maximum_length_usize)
-                    .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
-
-                // ... but not in `length`
-                length = maximum_length - mem::size_of::<u16>() as u16;
-            }
-            None => return Err(NtStringError::NulNotFound),
-        };
+        let (length, maximum_length) = check_from_u16_until_nul(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -314,25 +292,13 @@ impl<'a> TryFrom<&'a U16CStr> for NtUnicodeStr<'a> {
     /// The internal buffer will be NUL-terminated.
     /// See the [module-level documentation](super) for the implications of that.
     fn try_from(value: &'a U16CStr) -> Result<Self> {
-        let buffer = value.as_slice_with_nul();
-
-        // Include the terminating NUL character in `maximum_length` ...
-        let maximum_length_in_elements = buffer.len();
-        let maximum_length_in_bytes = maximum_length_in_elements
-            .checked_mul(mem::size_of::<u16>())
-            .ok_or(NtStringError::BufferSizeExceedsU16)?;
-        let maximum_length = u16::try_from(maximum_length_in_bytes)
-            .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
-
-        // ... but not in `length`
-        debug_assert!(maximum_length >= mem::size_of::<u16>() as u16);
-        let length = maximum_length - mem::size_of::<u16>() as u16;
+        let (length, maximum_length) = check_from_u16_cstr(value)?;
 
         Ok(Self {
             raw: RawNtString {
                 length,
                 maximum_length,
-                buffer: buffer.as_ptr(),
+                buffer: value.as_ptr(),
             },
             _lifetime: PhantomData,
         })

--- a/src/unicode_string/str.rs
+++ b/src/unicode_string/str.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Colin Finck <colin@reactos.org>
+// Copyright 2023-2026 Colin Finck <colin@reactos.org>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::cmp::Ordering;
@@ -10,9 +10,7 @@ use core::{fmt, mem, slice};
 use widestring::{U16CStr, U16Str};
 
 use crate::error::{NtStringError, Result};
-use crate::helpers::{
-    check_from_u16, check_from_u16_cstr, check_from_u16_until_nul, cmp_iter, RawNtString,
-};
+use crate::helpers::{cmp_iter, RawNtString};
 
 use super::iter::{Chars, CharsLossy};
 
@@ -160,7 +158,7 @@ impl<'a> NtUnicodeStr<'a> {
     ///
     /// [`try_from_u16_until_nul`]: Self::try_from_u16_until_nul
     pub fn try_from_u16(buffer: &'a [u16]) -> Result<Self> {
-        let length = check_from_u16(buffer)?;
+        let length = Self::try_length_from_u16(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -188,7 +186,7 @@ impl<'a> NtUnicodeStr<'a> {
     ///
     /// [`try_from_u16`]: Self::try_from_u16
     pub fn try_from_u16_until_nul(buffer: &'a [u16]) -> Result<Self> {
-        let (length, maximum_length) = check_from_u16_until_nul(buffer)?;
+        let (length, maximum_length) = Self::try_length_from_u16_until_nul(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -198,6 +196,57 @@ impl<'a> NtUnicodeStr<'a> {
             },
             _lifetime: PhantomData,
         })
+    }
+
+    pub(crate) fn try_length_from_u16(buffer: &[u16]) -> Result<u16> {
+        let elements = buffer.len();
+        let length_usize = elements
+            .checked_mul(mem::size_of::<u16>())
+            .ok_or(NtStringError::BufferSizeExceedsU16)?;
+        let length =
+            u16::try_from(length_usize).map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+
+        Ok(length)
+    }
+
+    pub(crate) fn try_length_from_u16_cstr(u16cstr: &U16CStr) -> Result<(u16, u16)> {
+        let buffer = u16cstr.as_slice_with_nul();
+
+        // Include the terminating NUL character in `maximum_length` ...
+        let maximum_length_in_elements = buffer.len();
+        let maximum_length_in_bytes = maximum_length_in_elements
+            .checked_mul(mem::size_of::<u16>())
+            .ok_or(NtStringError::BufferSizeExceedsU16)?;
+        let maximum_length = u16::try_from(maximum_length_in_bytes)
+            .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+
+        // ... but not in `length`
+        debug_assert!(maximum_length >= mem::size_of::<u16>() as u16);
+        let length = maximum_length - mem::size_of::<u16>() as u16;
+
+        Ok((length, maximum_length))
+    }
+
+    pub(crate) fn try_length_from_u16_until_nul(buffer: &[u16]) -> Result<(u16, u16)> {
+        match buffer.iter().position(|x| *x == 0) {
+            Some(nul_pos) => {
+                // Include the terminating NUL character in `maximum_length` ...
+                let maximum_elements = nul_pos
+                    .checked_add(1)
+                    .ok_or(NtStringError::BufferSizeExceedsU16)?;
+                let maximum_length_usize = maximum_elements
+                    .checked_mul(mem::size_of::<u16>())
+                    .ok_or(NtStringError::BufferSizeExceedsU16)?;
+                let maximum_length = u16::try_from(maximum_length_usize)
+                    .map_err(|_| NtStringError::BufferSizeExceedsU16)?;
+
+                // ... but not in `length`
+                let length = maximum_length - mem::size_of::<u16>() as u16;
+
+                Ok((length, maximum_length))
+            }
+            None => Err(NtStringError::NulNotFound),
+        }
     }
 
     pub(crate) fn u16_iter(&'a self) -> Copied<Iter<'a, u16>> {
@@ -292,7 +341,7 @@ impl<'a> TryFrom<&'a U16CStr> for NtUnicodeStr<'a> {
     /// The internal buffer will be NUL-terminated.
     /// See the [module-level documentation](super) for the implications of that.
     fn try_from(value: &'a U16CStr) -> Result<Self> {
-        let (length, maximum_length) = check_from_u16_cstr(value)?;
+        let (length, maximum_length) = Self::try_length_from_u16_cstr(value)?;
 
         Ok(Self {
             raw: RawNtString {

--- a/src/unicode_string/strmut.rs
+++ b/src/unicode_string/strmut.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Colin Finck <colin@reactos.org>
+// Copyright 2023-2026 Colin Finck <colin@reactos.org>
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use core::cmp::Ordering;
@@ -9,7 +9,7 @@ use core::{fmt, mem, slice};
 use widestring::{U16CStr, U16Str};
 
 use crate::error::Result;
-use crate::helpers::{check_from_u16, check_from_u16_cstr, check_from_u16_until_nul, RawNtString};
+use crate::helpers::RawNtString;
 use crate::NtStringError;
 
 use super::{impl_eq, impl_partial_cmp, NtUnicodeStr};
@@ -122,7 +122,7 @@ impl<'a> NtUnicodeStrMut<'a> {
     ///
     /// [`try_from_u16_until_nul`]: Self::try_from_u16_until_nul
     pub fn try_from_u16(buffer: &mut [u16]) -> Result<Self> {
-        let length = check_from_u16(buffer)?;
+        let length = NtUnicodeStr::try_length_from_u16(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -150,7 +150,7 @@ impl<'a> NtUnicodeStrMut<'a> {
     ///
     /// [`try_from_u16`]: Self::try_from_u16
     pub fn try_from_u16_until_nul(buffer: &mut [u16]) -> Result<Self> {
-        let (length, maximum_length) = check_from_u16_until_nul(buffer)?;
+        let (length, maximum_length) = NtUnicodeStr::try_length_from_u16_until_nul(buffer)?;
 
         Ok(Self {
             raw: RawNtString {
@@ -196,7 +196,7 @@ impl<'a> TryFrom<&'a mut U16CStr> for NtUnicodeStrMut<'a> {
     /// The internal buffer will be NUL-terminated.
     /// See the [module-level documentation](super) for the implications of that.
     fn try_from(value: &'a mut U16CStr) -> Result<Self> {
-        let (length, maximum_length) = check_from_u16_cstr(value)?;
+        let (length, maximum_length) = NtUnicodeStr::try_length_from_u16_cstr(value)?;
 
         Ok(Self {
             raw: RawNtString {

--- a/src/unicode_string/strmut.rs
+++ b/src/unicode_string/strmut.rs
@@ -9,7 +9,7 @@ use core::{fmt, mem, slice};
 use widestring::{U16CStr, U16Str};
 
 use crate::error::Result;
-use crate::helpers::RawNtString;
+use crate::helpers::{check_from_u16, check_from_u16_cstr, check_from_u16_until_nul, RawNtString};
 use crate::NtStringError;
 
 use super::{impl_eq, impl_partial_cmp, NtUnicodeStr};
@@ -122,14 +122,16 @@ impl<'a> NtUnicodeStrMut<'a> {
     ///
     /// [`try_from_u16_until_nul`]: Self::try_from_u16_until_nul
     pub fn try_from_u16(buffer: &mut [u16]) -> Result<Self> {
-        let unicode_str = NtUnicodeStr::try_from_u16(buffer)?;
+        let length = check_from_u16(buffer)?;
 
-        // SAFETY: `unicode_str` was created from a mutable `buffer` and
-        // `NtUnicodeStr` and `NtUnicodeStrMut` have the same memory layout,
-        // so we can safely transmute `NtUnicodeStr` to `NtUnicodeStrMut`.
-        let unicode_str_mut = unsafe { mem::transmute(unicode_str) };
-
-        Ok(unicode_str_mut)
+        Ok(Self {
+            raw: RawNtString {
+                length,
+                maximum_length: length,
+                buffer: buffer.as_mut_ptr(),
+            },
+            _lifetime: PhantomData,
+        })
     }
 
     /// Creates an [`NtUnicodeStrMut`] from an existing [`u16`] string buffer that contains at least one NUL character.
@@ -148,14 +150,16 @@ impl<'a> NtUnicodeStrMut<'a> {
     ///
     /// [`try_from_u16`]: Self::try_from_u16
     pub fn try_from_u16_until_nul(buffer: &mut [u16]) -> Result<Self> {
-        let unicode_str = NtUnicodeStr::try_from_u16_until_nul(buffer)?;
+        let (length, maximum_length) = check_from_u16_until_nul(buffer)?;
 
-        // SAFETY: `unicode_str` was created from a mutable `buffer` and
-        // `NtUnicodeStr` and `NtUnicodeStrMut` have the same memory layout,
-        // so we can safely transmute `NtUnicodeStr` to `NtUnicodeStrMut`.
-        let unicode_str_mut = unsafe { mem::transmute(unicode_str) };
-
-        Ok(unicode_str_mut)
+        Ok(Self {
+            raw: RawNtString {
+                length,
+                maximum_length,
+                buffer: buffer.as_mut_ptr(),
+            },
+            _lifetime: PhantomData,
+        })
     }
 }
 
@@ -192,14 +196,16 @@ impl<'a> TryFrom<&'a mut U16CStr> for NtUnicodeStrMut<'a> {
     /// The internal buffer will be NUL-terminated.
     /// See the [module-level documentation](super) for the implications of that.
     fn try_from(value: &'a mut U16CStr) -> Result<Self> {
-        let unicode_str = NtUnicodeStr::try_from(&*value)?;
+        let (length, maximum_length) = check_from_u16_cstr(value)?;
 
-        // SAFETY: `unicode_str` was created from a mutable `value` and
-        // `NtUnicodeStr` and `NtUnicodeStrMut` have the same memory layout,
-        // so we can safely transmute `NtUnicodeStr` to `NtUnicodeStrMut`.
-        let unicode_str_mut = unsafe { mem::transmute(unicode_str) };
-
-        Ok(unicode_str_mut)
+        Ok(Self {
+            raw: RawNtString {
+                length,
+                maximum_length,
+                buffer: value.as_mut_ptr(),
+            },
+            _lifetime: PhantomData,
+        })
     }
 }
 


### PR DESCRIPTION
Avoid transmuting an NtUnicodeStr into a NtUnicodeStrMut which is assigned a *const instead of a *mut for its buffer field.